### PR TITLE
Support for Custom Imported Models with User-Friendly IDs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+- Install dependencies: `cd src && uv pip install -r requirements.txt`
+- Run Python scripts: `cd src && uv run <script_name>.py`
+- Run locally: `cd src && uv run -m uvicorn api.app:app --host 0.0.0.0 --port 8000`
+- Build Docker: `cd scripts && bash ./push-to-ecr.sh`
+- Lint: `pipx run ruff check`
+- Format: `pipx run ruff format`
+
+## Environment Configuration
+- We use `uv` instead of regular `python` or `pip` commands
+- Enable debug mode: `export DEBUG=true`
+- Set AWS region: `export AWS_REGION=us-east-1`
+- Custom models are enabled by default
+
+## Code Style
+- Python version: 3.12
+- Line length: 120 characters max
+- Indentation: 4 spaces
+- Quote style: Double quotes for strings
+- Imports: Group (standard lib, third-party, internal) and alphabetically sorted
+- Use FastAPI patterns for API development
+- Type annotations required for all functions and classes
+- Use abstract base classes (ABC) for interfaces
+- Snake case for variables/functions, PascalCase for classes
+- Explicit error handling with specific exception types
+- Use HTTPException for API errors
+- Document public functions with docstrings
+
+## Architecture
+This project provides OpenAI-compatible RESTful APIs for Amazon Bedrock models, making it easy to use AWS foundation models without changing existing code that uses OpenAI APIs.
+
+## Testing
+- Test API functionality: `cd src && uv run test_api.py`
+- Test custom models: `cd src && uv run test_custom_models.py`

--- a/CUSTOM_MODELS_IMPLEMENTATION.md
+++ b/CUSTOM_MODELS_IMPLEMENTATION.md
@@ -1,0 +1,123 @@
+# Custom Imported Models Implementation
+
+## Overview
+
+This document describes the implementation of custom imported model support in the Bedrock Access Gateway. Custom models are models that you have imported into Bedrock, and this feature allows you to use them through the OpenAI-compatible API interface just like foundation models.
+
+## User-Friendly Model IDs
+
+One of the key features of this implementation is the creation of user-friendly model IDs that include the model name. Instead of cryptic AWS IDs like `custom.a1b2c3d4`, models are presented with descriptive IDs in the format:
+
+```
+{model-name}-id:custom.{aws_id}
+```
+
+For example: `mistral-7b-instruct-id:custom.a1b2c3d4`
+
+This makes it easier to identify models when using the Models API, while maintaining compatibility with the original AWS ID format.
+
+## Changes Made
+
+1. **Model Discovery**
+   - Extended `list_bedrock_models()` to include:
+     - Custom models via `bedrock_client.list_custom_models()`
+     - Imported models via `bedrock_client.list_imported_models()`
+   - Created user-friendly model IDs that include the model name
+   - Added type field to model metadata to distinguish between "foundation" and "custom" models
+   - Added region information to each model to support cross-region invocation
+   - Stored model ARN for custom models for invocation purposes
+
+2. **Configuration**
+   - Custom models are always enabled by default
+   - Added retry configuration for custom model invocation
+   - The implementation uses the local AWS region by default
+
+3. **Model Validation**
+   - Added ID transformation logic in the `validate()` method to handle both:
+     - Descriptive model IDs (e.g., `mistral-7b-instruct-id:custom.a1b2c3d4`)
+     - Original AWS IDs (e.g., `custom.a1b2c3d4`)
+   - Stores the original display ID to preserve it in responses
+
+4. **Model Invocation**
+   - Added branching logic in `_invoke_bedrock()` to handle custom models differently
+   - Implemented `_invoke_custom_model()` method to handle custom model invocation via `InvokeModel`/`InvokeModelWithResponseStream`
+   - Added custom model response parsing to handle various model output formats
+   - Implemented special handling for `ModelNotReadyException`
+   - Added region-specific client creation for cross-region models
+
+5. **Streaming Support**
+   - Added `_handle_custom_model_stream()` method to handle streaming responses
+   - Added support for parsing different streaming formats from custom models
+
+6. **Message Formatting**
+   - Implemented `_create_prompt_from_messages()` to convert OpenAI-style chat messages to text format for custom models
+
+7. **Documentation**
+   - Updated README.md to include new feature
+   - Updated Usage.md with custom model usage examples
+   - Updated FAQs to indicate custom model support
+
+## Usage
+
+### Listing Custom Models
+
+To list available custom models in your AWS account, use the Models API:
+
+```bash
+curl -s $OPENAI_BASE_URL/models -H "Authorization: Bearer $OPENAI_API_KEY" | jq '.data[] | select(.id | startswith("custom.") or contains("-id:custom."))'
+```
+
+### Using Custom Models
+
+Custom models can be used with either their descriptive ID or the original AWS ID:
+
+```bash
+# Using descriptive ID
+curl $OPENAI_BASE_URL/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -d '{
+    "model": "mistral-7b-instruct-id:custom.a1b2c3d4",
+    "messages": [
+      { "role": "user", "content": "Hello, world!" }
+    ]
+  }'
+
+# Using original AWS ID (also supported)
+curl $OPENAI_BASE_URL/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -d '{
+    "model": "custom.a1b2c3d4",
+    "messages": [
+      { "role": "user", "content": "Hello, world!" }
+    ]
+  }'
+```
+
+## Troubleshooting
+
+### Model Not Found
+
+If your custom model isn't appearing:
+
+1. Check if the model exists in your AWS account:
+   ```bash
+   aws bedrock list-imported-models --region us-east-1
+   ```
+
+2. Restart the gateway to refresh the model list:
+   ```bash
+   # For Lambda deployments
+   # Go to Lambda console > Find your function > Click "Deploy new image"
+   
+   # For Fargate deployments
+   # Go to ECS console > Find your cluster > Tasks tab > Stop running task
+   ```
+
+### Invocation Errors
+
+Common errors when invoking custom models:
+
+- `ModelNotReadyException`: The model is still being prepared - wait a few minutes and try again
+- `ValidationException`: Check that your input format is compatible with the model

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ If you find this GitHub repository useful, please consider giving it a free star
 - [x] Support Embedding API
 - [x] Support Multimodal API
 - [x] Support Cross-Region Inference
-- [x] Support Reasoning (**new**)
+- [x] Support Reasoning
+- [x] Support Custom Imported Models (**new**)
 
 Please check [Usage Guide](./docs/Usage.md) for more details about how to use the new APIs.
 
@@ -230,9 +231,13 @@ Also, you can use Lambda Web Adapter + Function URL (see [example](https://githu
 
 Currently, there is no plan to support SageMaker models. This may change provided there's a demand from customers.
 
-### Any plan to support Bedrock custom models?
+### Support for Bedrock custom models
 
-Fine-tuned models and models with Provisioned Throughput are currently not supported. You can clone the repo and make the customization if needed.
+Custom imported models are now supported! You can use them just like foundation models using user-friendly model IDs in the format `{model-name}-id:custom.{aws_id}` or with the original AWS format `custom.{aws_id}`. Run the Models API to see the available custom models in your account.
+
+The user-friendly format makes it easier to identify models while maintaining backward compatibility with the original AWS IDs. For more details, see [Custom Imported Models](./docs/Usage.md#custom-imported-models) in the usage documentation.
+
+Fine-tuned models and models with Provisioned Throughput may require additional configuration.
 
 ### How to upgrade?
 

--- a/deployment/BedrockProxy.template
+++ b/deployment/BedrockProxy.template
@@ -8,6 +8,9 @@ Parameters:
     Type: String
     Default: anthropic.claude-3-sonnet-20240229-v1:0
     Description: The default model ID, please make sure the model ID is supported in the current region
+  EcrAccountId:
+    Type: String
+    Default: 366590864501
 Resources:
   VPCB9E5F0B4:
     Type: AWS::EC2::VPC
@@ -170,7 +173,8 @@ Resources:
         ImageUri:
           Fn::Join:
             - ""
-            - - 366590864501.dkr.ecr.
+            - - Ref: EcrAccountId
+              - ".dkr.ecr."
               - Ref: AWS::Region
               - "."
               - Ref: AWS::URLSuffix

--- a/deployment/BedrockProxyFargate.template
+++ b/deployment/BedrockProxyFargate.template
@@ -8,6 +8,9 @@ Parameters:
     Type: String
     Default: anthropic.claude-3-sonnet-20240229-v1:0
     Description: The default model ID, please make sure the model ID is supported in the current region
+  EcrAccountId:
+    Type: String
+    Default: 366590864501
 Resources:
   VPCB9E5F0B4:
     Type: AWS::EC2::VPC
@@ -158,7 +161,9 @@ Resources:
                 - ""
                 - - "arn:aws:ecr:"
                   - Ref: AWS::Region
-                  - :366590864501:repository/bedrock-proxy-api-ecs
+                  - ":"
+                  - Ref: EcrAccountId
+                  - :repository/bedrock-proxy-api-ecs
           - Action: ecr:GetAuthorizationToken
             Effect: Allow
             Resource: "*"
@@ -226,7 +231,8 @@ Resources:
           Image:
             Fn::Join:
               - ""
-              - - 366590864501.dkr.ecr.
+              - - Ref: EcrAccountId
+                - ".dkr.ecr."
                 - Ref: AWS::Region
                 - "."
                 - Ref: AWS::URLSuffix

--- a/src/api/models/bedrock.py
+++ b/src/api/models/bedrock.py
@@ -1012,10 +1012,17 @@ class BedrockModel(BaseChatModel):
                 completion_text = ""
                 input_tokens = 0
                 output_tokens = 0
+                
+                # Debug log all keys to help troubleshoot response formats
+                if DEBUG:
+                    logger.info(f"Response body keys: {list(response_body.keys())}")
 
                 # Handle different response formats based on model type
                 if "completion" in response_body:
                     completion_text = response_body["completion"]
+                elif "generation" in response_body:
+                    # Handle format used by some imported models
+                    completion_text = response_body["generation"]
                 elif "generations" in response_body and isinstance(response_body["generations"], list):
                     # Handle formats like Anthropic Claude style
                     completion_text = response_body["generations"][0].get("text", "")
@@ -1030,6 +1037,10 @@ class BedrockModel(BaseChatModel):
                 if "usage" in response_body:
                     input_tokens = response_body["usage"].get("prompt_tokens", 0)
                     output_tokens = response_body["usage"].get("completion_tokens", 0)
+                elif "prompt_token_count" in response_body:
+                    # Format used by some imported models
+                    input_tokens = response_body.get("prompt_token_count", 0)
+                    output_tokens = response_body.get("generation_token_count", 0)
 
                 # Create a response structure that matches the converse API response
                 return {

--- a/src/api/schema.py
+++ b/src/api/schema.py
@@ -102,6 +102,7 @@ class ChatRequest(BaseModel):
     tools: list[Tool] | None = None
     tool_choice: str | object = "auto"
     stop: list[str] | str | None = None
+    custom_model_display_name: str | None = None  # For storing the friendly model name when using custom models
 
 
 class Usage(BaseModel):

--- a/src/api/setting.py
+++ b/src/api/setting.py
@@ -16,3 +16,5 @@ AWS_REGION = os.environ.get("AWS_REGION", "us-west-2")
 DEFAULT_MODEL = os.environ.get("DEFAULT_MODEL", "anthropic.claude-3-sonnet-20240229-v1:0")
 DEFAULT_EMBEDDING_MODEL = os.environ.get("DEFAULT_EMBEDDING_MODEL", "cohere.embed-multilingual-v3")
 ENABLE_CROSS_REGION_INFERENCE = os.environ.get("ENABLE_CROSS_REGION_INFERENCE", "true").lower() != "false"
+# Custom models are always enabled by default
+ENABLE_CUSTOM_MODELS = True

--- a/src/test_custom_models.py
+++ b/src/test_custom_models.py
@@ -1,0 +1,153 @@
+import json
+import logging
+import os
+import sys
+import unittest
+
+import boto3
+from botocore.config import Config
+from fastapi.testclient import TestClient
+
+# Add the src directory to the path so we can import from api
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from api.app import app
+from api.models.bedrock import list_bedrock_models
+from api.setting import DEFAULT_API_KEYS, ENABLE_CUSTOM_MODELS
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+# Create a test client with authentication
+client = TestClient(app)
+# Set up default authentication headers
+client.headers.update({"Authorization": f"Bearer {DEFAULT_API_KEYS}"})
+
+# Configure AWS client
+config = Config(connect_timeout=60, read_timeout=120, retries={"max_attempts": 1})
+AWS_REGION = os.environ.get("AWS_REGION", "us-west-2")
+
+
+def get_custom_model_id() -> str:
+    """Find a custom model to test with. Raises AssertionError if none found."""
+    # Make sure custom models are enabled
+    assert ENABLE_CUSTOM_MODELS is True, "Custom models are not enabled"
+
+    # Get the list of models
+    model_list = list_bedrock_models()
+
+    # Find custom models
+    custom_models = {k: v for k, v in model_list.items() if v.get("type") == "custom"}
+
+    # Require at least one custom model for testing
+    assert custom_models, "No custom models found. Tests require at least one custom imported model."
+
+    # Return the first custom model ID
+    model_id = list(custom_models.keys())[0]
+    logger.info(f"Using custom model: {model_id}")
+    return model_id
+
+
+class TestCustomModels(unittest.TestCase):
+    """Integration tests for custom imported models."""
+
+    def test_list_models_includes_custom_models(self):
+        """Test that the model list includes custom models."""
+        # Get the list of models
+        response = client.get("/api/v1/models")
+        self.assertEqual(response.status_code, 200)
+
+        # Parse the response
+        data = response.json()
+        self.assertIn("data", data)
+
+        # Get model IDs
+        model_ids = [model["id"] for model in data["data"]]
+
+        # Check if any custom models are included
+        custom_model_found = False
+        for model_id in model_ids:
+            if "-id:custom." in model_id:
+                custom_model_found = True
+                logger.info(f"Found custom model in response: {model_id}")
+                break
+
+        self.assertTrue(custom_model_found, "No custom models found in model list")
+
+    def test_custom_model_invocation(self):
+        """Test that a custom model can be invoked successfully."""
+        # Get a custom model ID - will fail if none available
+        model_id = get_custom_model_id()
+
+        # Create a request payload
+        payload = {
+            "model": model_id,
+            "messages": [{"role": "user", "content": "Hello, how are you?"}],
+            "max_tokens": 100,
+        }
+
+        # Send the request
+        response = client.post("/api/v1/chat/completions", json=payload)
+
+        # Check the response status
+        self.assertEqual(response.status_code, 200, f"Failed to invoke custom model: {response.text}")
+
+        # Parse the response
+        data = response.json()
+
+        # Verify the response structure
+        self.assertIn("choices", data)
+        self.assertTrue(len(data["choices"]) > 0)
+        self.assertIn("message", data["choices"][0])
+        self.assertIn("content", data["choices"][0]["message"])
+
+        # Verify that the content is not empty
+        content = data["choices"][0]["message"]["content"]
+        self.assertTrue(content and len(content) > 0, "Response content is empty")
+
+        # Log the response for debugging
+        logger.info(f"Received response from custom model: {content[:100]}...")
+
+    def test_custom_model_streaming(self):
+        """Test that a custom model can be used with streaming."""
+        # Get a custom model ID - will fail if none available
+        model_id = get_custom_model_id()
+
+        # Create a request payload with streaming enabled
+        payload = {
+            "model": model_id,
+            "messages": [{"role": "user", "content": "Hello, what's your name?"}],
+            "max_tokens": 100,
+            "stream": True,
+        }
+
+        # Send the request
+        response = client.post("/api/v1/chat/completions", json=payload)
+
+        # Check the response status
+        self.assertEqual(response.status_code, 200, "Failed to stream from custom model")
+
+        # For the TestClient, we'll verify the headers indicate streaming
+        self.assertTrue(
+            response.headers["content-type"].startswith("text/event-stream"), "Response is not a streaming response"
+        )
+
+        # Read some content to verify it's working
+        chunk_count = 0
+        content = response.content.decode("utf-8")
+
+        # Simple check - streaming responses contain "data:" lines
+        self.assertIn("data:", content, "No streaming data found in response")
+
+        # Count data chunks
+        for line in content.split("\n"):
+            if line.startswith("data:"):
+                chunk_count += 1
+
+        # Verify we got some chunks
+        self.assertTrue(chunk_count > 0, "No chunks received from streaming")
+        logger.info(f"Received {chunk_count} data chunks from streaming response")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/test_direct_invoke.py
+++ b/src/test_direct_invoke.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+import boto3
+import json
+import logging
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+# Custom model ID and region
+CUSTOM_MODEL_ID = "arn:aws:bedrock:us-east-1:529237317113:imported-model/okp1jkklp8kk"
+REGION = "us-east-1"
+MAX_TOKENS = 100
+
+# Create a Bedrock Runtime client
+bedrock_runtime = boto3.client(
+    service_name="bedrock-runtime",
+    region_name=REGION,
+)
+
+# Test direct invocation
+def test_direct_invocation():
+    """Test direct invocation of the custom model."""
+    logger.info(f"Testing direct invocation of {CUSTOM_MODEL_ID}")
+
+    # Create a request body
+    body = {
+        "prompt": "Human: Hello, how are you?\nAssistant:",
+        "max_tokens": MAX_TOKENS,
+        "temperature": 0.7,
+    }
+
+    try:
+        # Invoke the model
+        response = bedrock_runtime.invoke_model(
+            modelId=CUSTOM_MODEL_ID,
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+
+        # Parse the response
+        response_body = json.loads(response["body"].read())
+        logger.info(f"Response: {json.dumps(response_body, indent=2)}")
+
+        # Check for content
+        if "completion" in response_body:
+            logger.info(f"Completion: {response_body['completion']}")
+        elif "generation" in response_body:
+            logger.info(f"Generation: {response_body['generation']}")
+        elif "generations" in response_body and len(response_body["generations"]) > 0:
+            logger.info(f"Generation: {response_body['generations'][0].get('text', '')}")
+        elif "generated_text" in response_body:
+            logger.info(f"Generated text: {response_body['generated_text']}")
+        elif "choices" in response_body and len(response_body["choices"]) > 0:
+            logger.info(f"Choice: {response_body['choices'][0].get('text', '')}")
+        else:
+            logger.warning(f"Unknown response format: {response_body}")
+
+        return True
+
+    except Exception as e:
+        logger.error(f"Error invoking model: {str(e)}")
+        return False
+
+# Test streaming invocation
+def test_streaming_invocation():
+    """Test streaming invocation of the custom model."""
+    logger.info(f"Testing streaming invocation of {CUSTOM_MODEL_ID}")
+
+    # Create a request body
+    body = {
+        "prompt": "Human: Tell me about quantum computing in simple terms.\nAssistant:",
+        "max_tokens": MAX_TOKENS,
+        "temperature": 0.7,
+    }
+
+    try:
+        # Invoke the model with streaming
+        response = bedrock_runtime.invoke_model_with_response_stream(
+            modelId=CUSTOM_MODEL_ID,
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+
+        # Process the streaming response
+        stream = response.get("body")
+        full_response = ""
+        
+        logger.info("Streaming chunks:")
+        for chunk in stream:
+            # Log raw chunk info (only first few to avoid flooding logs)
+            if full_response == "":
+                logger.info(f"Raw chunk: {chunk}")
+                
+            # For the imported models, the contentType might be missing from each chunk
+            # but we can still process the chunks
+                
+            try:
+                chunk_bytes = chunk.get("chunk", {}).get("bytes")
+                if not chunk_bytes:
+                    logger.warning("No bytes in chunk")
+                    continue
+                    
+                chunk_body = json.loads(chunk_bytes.decode())
+                logger.info(f"Chunk body: {json.dumps(chunk_body)}")
+                
+                # Extract text based on common response formats
+                text = None
+                if "completion" in chunk_body:
+                    text = chunk_body["completion"]
+                elif "generation" in chunk_body:
+                    text = chunk_body["generation"]
+                    logger.info(f"Found generation field: {text}")
+                elif "delta" in chunk_body:
+                    text = chunk_body["delta"]
+                elif "content" in chunk_body:
+                    text = chunk_body["content"]
+                elif "text" in chunk_body:
+                    text = chunk_body["text"]
+                
+                if text:
+                    full_response += text
+                    logger.info(f"Extracted text: {text}")
+                else:
+                    logger.warning(f"No text extracted from chunk: {chunk_body}")
+            except Exception as e:
+                logger.error(f"Error processing chunk: {str(e)}")
+        
+        logger.info(f"Full response: {full_response}")
+        return len(full_response) > 0
+
+    except Exception as e:
+        logger.error(f"Error in streaming: {str(e)}")
+        return False
+
+if __name__ == "__main__":
+    # Run both tests
+    direct_result = test_direct_invocation()
+    streaming_result = test_streaming_invocation()
+    
+    if direct_result and streaming_result:
+        logger.info("All tests passed")
+    elif direct_result:
+        logger.info("Direct invocation test passed, streaming test failed")
+    elif streaming_result:
+        logger.info("Streaming test passed, direct invocation test failed")
+    else:
+        logger.info("All tests failed")


### PR DESCRIPTION
## Summary
- Add support for custom models imported into AWS Bedrock
- Create user-friendly model IDs that include the model name (e.g., `mistral-7b-instruct-id:custom.a1b2c3d4`)
- Maintain backward compatibility with original AWS IDs
- Preserve the user-friendly IDs in API responses

## Key Features
- Custom models are always enabled by default
- Models are discovered automatically from the AWS account
- User-friendly IDs are created based on model names
- Complete documentation in CUSTOM_MODELS_IMPLEMENTATION.md 
- Support for both streaming and non-streaming requests
- Support for model invocation across regions

## Test plan
1. Run the Models API to verify custom models appear with user-friendly IDs
2. Test chat completions with both ID formats (user-friendly and original AWS format)
3. Test streaming with custom models
4. Verify that responses preserve the user-friendly IDs

🤖 Generated with [Claude Code](https://claude.ai/code)